### PR TITLE
Add remote access support

### DIFF
--- a/common/params.py
+++ b/common/params.py
@@ -17,3 +17,36 @@ if __name__ == "__main__":
     params.put(key, val)
   elif len(sys.argv) == 2:
     print(f"GET: {key} = {params.get(key)}")
+
+# BEGIN_REMOTE_ACCESS  # SPDX-License-Identifier: MIT (c) 2025 Saeed Almansoori
+# Remote Access params
+try:
+  _params_types  # hint: some trees use PARAMS or _params_types; we guard both
+except NameError:
+  pass
+
+# Generic registries seen across forks
+for _name, _ptype, _default in [
+  ("EnableRemoteAccess", "bool", b"0"),
+  ("RemoteAccessLoginURL", "bytes", b""),
+]:
+  try:
+    # OpenPilot style
+    if 'keys' in globals() and isinstance(keys, dict) and _name not in keys:
+      keys[_name] = (_ptype, _default)
+  except Exception:
+    pass
+  try:
+    # Alternate registry (_keys or _params_types)
+    if '_keys' in globals() and isinstance(_keys, dict) and _name not in _keys:
+      _keys[_name] = (_ptype, _default)
+  except Exception:
+    pass
+  try:
+    if '_params_types' in globals() and isinstance(_params_types, dict) and _name not in _params_types:
+      _params_types[_name] = _ptype
+      if '_default_values' in globals() and isinstance(_default_values, dict):
+        _default_values[_name] = _default
+  except Exception:
+    pass
+# END_REMOTE_ACCESS

--- a/common/params_keys.h
+++ b/common/params_keys.h
@@ -321,4 +321,6 @@ inline static std::unordered_map<std::string, ParamKeyAttributes> keys = {
     {"LFAButtonEngagement", {PERSISTENT, BOOL, "0"}},
     {"TimeFactorModHours", {PERSISTENT, STRING, "0"}},
     {"TimeFactorModMinutes", {PERSISTENT, STRING, "0"}},
+    {"EnableRemoteAccess", {PERSISTENT, BOOL, "0"}},
+    {"RemoteAccessLoginURL", {PERSISTENT, STRING, ""}},
 };

--- a/selfdrive/remote/remote_agent.py
+++ b/selfdrive/remote/remote_agent.py
@@ -1,0 +1,81 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 Saeed Almansoori
+"""
+Remote Access Agent
+- Watches 'EnableRemoteAccess' param
+- Installs Tailscale if missing
+- Runs 'tailscaled' and 'tailscale up'
+- Captures login URL and stores it in 'RemoteAccessLoginURL'
+- On disable: 'tailscale down' and clears URL
+"""
+import os, re, subprocess, time, shlex, pathlib, sys
+
+PARAMS_DIR = os.environ.get("PARAMS_DIR", "/data/params/d")
+P_ENABLE = "EnableRemoteAccess"
+P_URL    = "RemoteAccessLoginURL"
+
+def ppath(name): return os.path.join(PARAMS_DIR, name)
+
+def read_param(name, default=b""):
+  try:
+    with open(ppath(name), "rb") as f: return f.read()
+  except Exception: return default
+
+def write_param(name, data: bytes):
+  pathlib.Path(PARAMS_DIR).mkdir(parents=True, exist_ok=True)
+  with open(ppath(name), "wb") as f: f.write(data)
+
+def shell(cmd, capture=False):
+  if capture:
+    return subprocess.run(cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True).stdout
+  return subprocess.run(cmd, shell=True, check=False)
+
+def ensure_tailscale():
+  # install if missing
+  code = subprocess.call("command -v tailscale >/dev/null 2>&1", shell=True)
+  if code != 0:
+    # silent install; safe if already present
+    shell("curl -fsSL https://tailscale.com/install.sh | sh")
+  # ensure daemon
+  shell("pgrep -x tailscaled >/dev/null || nohup tailscaled >/dev/null 2>&1 &")
+
+def extract_login_url(output: str) -> str:
+  # tailscale up usually prints a URL like: https://login.tailscale.com/a/abcdef...
+  m = re.search(r'https?://\S+', output)
+  return m.group(0) if m else ""
+
+def bring_up():
+  ensure_tailscale()
+  # Try to reset and bring up; capture URL if needs-login
+  out = shell("tailscale up --ssh --reset 2>&1 || true", capture=True)
+  url = extract_login_url(out)
+  if not url:
+    # already logged in OR another message; query status for URL in pending state
+    st = shell("tailscale status 2>&1 || true", capture=True)
+    u2 = extract_login_url(st)
+    url = u2 or url
+  write_param(P_URL, url.encode() if url else b"")
+  return url
+
+def bring_down():
+  shell("tailscale down >/dev/null 2>&1 || true")
+  write_param(P_URL, b"")
+
+def main():
+  last = None
+  while True:
+    v = read_param(P_ENABLE, b"0")
+    on = (v == b"1")
+    if on != last:
+      if on:
+        bring_up()
+      else:
+        bring_down()
+      last = on
+    time.sleep(2)
+
+if __name__ == "__main__":
+  try:
+    main()
+  except KeyboardInterrupt:
+    sys.exit(0)

--- a/selfdrive/ui/qt/network/networking.cc
+++ b/selfdrive/ui/qt/network/networking.cc
@@ -2,21 +2,67 @@
 
 #include <algorithm>
 
+#include <QClipboard>
+#include <QGuiApplication>
 #include <QHBoxLayout>
 #include <QScrollBar>
 #include <QStyle>
+#include <QTimer>
+#include <QVBoxLayout>
 
-#include "selfdrive/ui/ui.h"
+#include "common/params.h"
 #include "selfdrive/ui/qt/qt_window.h"
 #include "selfdrive/ui/qt/util.h"
 #include "selfdrive/ui/qt/widgets/controls.h"
 #include "selfdrive/ui/qt/widgets/scrollview.h"
+#include "selfdrive/ui/ui.h"
 
 static const int ICON_WIDTH = 49;
 
 // Networking functions
 
-Networking::Networking(QWidget* parent, bool show_advanced) : QFrame(parent) {
+class RemoteAccessWidget : public QWidget {
+public:
+  explicit RemoteAccessWidget(QWidget *parent = nullptr) : QWidget(parent) {
+    QVBoxLayout *lay = new QVBoxLayout(this);
+    toggle_ = new ParamControl(
+        "EnableRemoteAccess", QObject::tr("Remote Access"),
+        QObject::tr("Enable secure remote access for support and maintenance."),
+        "");
+    lay->addWidget(toggle_);
+
+    QWidget *row = new QWidget(this);
+    QHBoxLayout *h = new QHBoxLayout(row);
+    h->setContentsMargins(0, 0, 0, 0);
+    url_ = new LabelControl(QObject::tr("Login Link"), "");
+    QPushButton *copyBtn = new QPushButton(QObject::tr("Copy"));
+    QObject::connect(copyBtn, &QPushButton::clicked, [this]() {
+      QGuiApplication::clipboard()->setText(current_url_);
+    });
+    h->addWidget(url_);
+    h->addWidget(copyBtn);
+    lay->addWidget(row);
+
+    timer_ = new QTimer(this);
+    QObject::connect(timer_, &QTimer::timeout, [this]() { refreshURL(); });
+    timer_->start(1500);
+    refreshURL();
+  }
+
+private:
+  void refreshURL() {
+    Params p;
+    current_url_ = QString::fromStdString(p.get("RemoteAccessLoginURL"));
+    url_->setText(current_url_);
+  }
+
+  ParamControl *toggle_ = nullptr;
+  LabelControl *url_ = nullptr;
+  QTimer *timer_ = nullptr;
+  QString current_url_;
+};
+
+Networking::Networking(QWidget *parent, bool show_advanced) : QFrame(parent) {
   main_layout = new QStackedLayout(this);
 
   wifi = new WifiManager(this);
@@ -25,22 +71,26 @@ Networking::Networking(QWidget* parent, bool show_advanced) : QFrame(parent) {
   connect(uiState(), &UIState::hotspotSignal, this, &Networking::hotspoton);
 
   wifiScreen = new QWidget(this);
-  QVBoxLayout* vlayout = new QVBoxLayout(wifiScreen);
+  QVBoxLayout *vlayout = new QVBoxLayout(wifiScreen);
   vlayout->setContentsMargins(20, 20, 20, 20);
   if (show_advanced) {
-    QPushButton* advancedSettings = new QPushButton(tr("Advanced"));
+    QPushButton *advancedSettings = new QPushButton(tr("Advanced"));
     advancedSettings->setObjectName("advanced_btn");
     advancedSettings->setStyleSheet("margin-right: 30px;");
     advancedSettings->setFixedSize(400, 100);
-    connect(advancedSettings, &QPushButton::clicked, [=]() { main_layout->setCurrentWidget(an); });
+    connect(advancedSettings, &QPushButton::clicked,
+            [=]() { main_layout->setCurrentWidget(an); });
     vlayout->addSpacing(10);
     vlayout->addWidget(advancedSettings, 0, Qt::AlignRight);
     vlayout->addSpacing(10);
   }
 
+  vlayout->addWidget(new RemoteAccessWidget(this));
+
   wifiWidget = new WifiUI(this, wifi);
   wifiWidget->setObjectName("wifiWidget");
-  connect(wifiWidget, &WifiUI::connectToNetwork, this, &Networking::connectToNetwork);
+  connect(wifiWidget, &WifiUI::connectToNetwork, this,
+          &Networking::connectToNetwork);
 
   ScrollView *wifiScroller = new ScrollView(wifiWidget, this);
   wifiScroller->setVerticalScrollBarPolicy(Qt::ScrollBarAsNeeded);
@@ -48,8 +98,10 @@ Networking::Networking(QWidget* parent, bool show_advanced) : QFrame(parent) {
   main_layout->addWidget(wifiScreen);
 
   an = new AdvancedNetworking(this, wifi);
-  connect(an, &AdvancedNetworking::backPress, [=]() { main_layout->setCurrentWidget(wifiScreen); });
-  connect(an, &AdvancedNetworking::requestWifiScreen, [=]() { main_layout->setCurrentWidget(wifiScreen); });
+  connect(an, &AdvancedNetworking::backPress,
+          [=]() { main_layout->setCurrentWidget(wifiScreen); });
+  connect(an, &AdvancedNetworking::requestWifiScreen,
+          [=]() { main_layout->setCurrentWidget(wifiScreen); });
   main_layout->addWidget(an);
 
   QPalette pal = palette();
@@ -75,8 +127,10 @@ Networking::Networking(QWidget* parent, bool show_advanced) : QFrame(parent) {
 }
 
 void Networking::setPrimeType(PrimeState::Type type) {
-  an->setGsmVisible(type == PrimeState::PRIME_TYPE_NONE || type == PrimeState::PRIME_TYPE_LITE);
-  wifi->ipv4_forward = (type == PrimeState::PRIME_TYPE_NONE || type == PrimeState::PRIME_TYPE_LITE);
+  an->setGsmVisible(type == PrimeState::PRIME_TYPE_NONE ||
+                    type == PrimeState::PRIME_TYPE_LITE);
+  wifi->ipv4_forward = (type == PrimeState::PRIME_TYPE_NONE ||
+                        type == PrimeState::PRIME_TYPE_LITE);
 }
 
 void Networking::refresh() {
@@ -96,7 +150,9 @@ void Networking::connectToNetwork(const Network n) {
   } else if (n.security_type == SecurityType::OPEN) {
     wifi->connect(n, false);
   } else if (n.security_type == SecurityType::WPA) {
-    QString pass = InputDialog::getText(tr("Enter password"), this, tr("for \"%1\"").arg(QString::fromUtf8(n.ssid)), true, 8);
+    QString pass = InputDialog::getText(
+        tr("Enter password"), this,
+        tr("for \"%1\"").arg(QString::fromUtf8(n.ssid)), true, 8);
     if (!pass.isEmpty()) {
       wifi->connect(n, false, pass);
     }
@@ -106,16 +162,16 @@ void Networking::connectToNetwork(const Network n) {
 void Networking::wrongPassword(const QString &ssid) {
   if (wifi->seenNetworks.contains(ssid)) {
     const Network &n = wifi->seenNetworks.value(ssid);
-    QString pass = InputDialog::getText(tr("Wrong password"), this, tr("for \"%1\"").arg(QString::fromUtf8(n.ssid)), true, 8);
+    QString pass = InputDialog::getText(
+        tr("Wrong password"), this,
+        tr("for \"%1\"").arg(QString::fromUtf8(n.ssid)), true, 8);
     if (!pass.isEmpty()) {
       wifi->connect(n, false, pass);
     }
   }
 }
 
-void Networking::showEvent(QShowEvent *event) {
-  wifi->start();
-}
+void Networking::showEvent(QShowEvent *event) { wifi->start(); }
 
 void Networking::hideEvent(QHideEvent *event) {
   main_layout->setCurrentWidget(wifiScreen);
@@ -124,14 +180,15 @@ void Networking::hideEvent(QHideEvent *event) {
 
 // AdvancedNetworking functions
 
-AdvancedNetworking::AdvancedNetworking(QWidget* parent, WifiManager* wifi): QWidget(parent), wifi(wifi) {
+AdvancedNetworking::AdvancedNetworking(QWidget *parent, WifiManager *wifi)
+    : QWidget(parent), wifi(wifi) {
 
-  QVBoxLayout* main_layout = new QVBoxLayout(this);
+  QVBoxLayout *main_layout = new QVBoxLayout(this);
   main_layout->setMargin(40);
   main_layout->setSpacing(20);
 
   // Back button
-  QPushButton* back = new QPushButton(tr("Back"));
+  QPushButton *back = new QPushButton(tr("Back"));
   back->setObjectName("back_btn");
   back->setFixedSize(400, 100);
   connect(back, &QPushButton::clicked, [=]() { emit backPress(); });
@@ -140,22 +197,31 @@ AdvancedNetworking::AdvancedNetworking(QWidget* parent, WifiManager* wifi): QWid
   ListWidget *list = new ListWidget(this);
   // Enable tethering layout
   const bool hotspotEnabled = params.getBool("KisaHotspotOnBoot");
-  tetheringToggle = new ToggleControl(tr("Enable Tethering"), "", "", wifi->isTetheringEnabled() || hotspotEnabled);
+  tetheringToggle =
+      new ToggleControl(tr("Enable Tethering"), "", "",
+                        wifi->isTetheringEnabled() || hotspotEnabled);
   list->addItem(tetheringToggle);
-  QObject::connect(tetheringToggle, &ToggleControl::toggleFlipped, this, &AdvancedNetworking::toggleTethering);
+  QObject::connect(tetheringToggle, &ToggleControl::toggleFlipped, this,
+                   &AdvancedNetworking::toggleTethering);
 
   // Hotspot Autorun toggle
-  hotspotToggle = new ToggleControl(tr("Hotspot Autorun"), "", "", hotspotEnabled);
-  QObject::connect(hotspotToggle, &ToggleControl::toggleFlipped, [=](bool state) {
-    params.putBool("KisaHotspotOnBoot", state);
-    if (state) toggleTethering(state);
-  });
+  hotspotToggle =
+      new ToggleControl(tr("Hotspot Autorun"), "", "", hotspotEnabled);
+  QObject::connect(hotspotToggle, &ToggleControl::toggleFlipped,
+                   [=](bool state) {
+                     params.putBool("KisaHotspotOnBoot", state);
+                     if (state)
+                       toggleTethering(state);
+                   });
   list->addItem(hotspotToggle);
 
   // Change tethering password
-  ButtonControl *editPasswordButton = new ButtonControl(tr("Tethering Password"), tr("EDIT"));
+  ButtonControl *editPasswordButton =
+      new ButtonControl(tr("Tethering Password"), tr("EDIT"));
   connect(editPasswordButton, &ButtonControl::clicked, [=]() {
-    QString pass = InputDialog::getText(tr("Enter new tethering password"), this, "", true, 8, wifi->getTetheringPassword());
+    QString pass =
+        InputDialog::getText(tr("Enter new tethering password"), this, "", true,
+                             8, wifi->getTetheringPassword());
     if (!pass.isEmpty()) {
       wifi->changeTetheringPassword(pass);
     }
@@ -168,57 +234,79 @@ AdvancedNetworking::AdvancedNetworking(QWidget* parent, WifiManager* wifi): QWid
 
   // Roaming toggle
   const bool roamingEnabled = params.getBool("GsmRoaming");
-  roamingToggle = new ToggleControl(tr("Enable Roaming"), "", "", roamingEnabled);
-  QObject::connect(roamingToggle, &ToggleControl::toggleFlipped, [=](bool state) {
-    params.putBool("GsmRoaming", state);
-    wifi->updateGsmSettings(state, QString::fromStdString(params.get("GsmApn")), params.getBool("GsmMetered"));
-  });
+  roamingToggle =
+      new ToggleControl(tr("Enable Roaming"), "", "", roamingEnabled);
+  QObject::connect(
+      roamingToggle, &ToggleControl::toggleFlipped, [=](bool state) {
+        params.putBool("GsmRoaming", state);
+        wifi->updateGsmSettings(state,
+                                QString::fromStdString(params.get("GsmApn")),
+                                params.getBool("GsmMetered"));
+      });
   list->addItem(roamingToggle);
 
   // APN settings
   editApnButton = new ButtonControl(tr("APN Setting"), tr("EDIT"));
   connect(editApnButton, &ButtonControl::clicked, [=]() {
     const QString cur_apn = QString::fromStdString(params.get("GsmApn"));
-    QString apn = InputDialog::getText(tr("Enter APN"), this, tr("leave blank for automatic configuration"), false, -1, cur_apn).trimmed();
+    QString apn =
+        InputDialog::getText(tr("Enter APN"), this,
+                             tr("leave blank for automatic configuration"),
+                             false, -1, cur_apn)
+            .trimmed();
 
     if (apn.isEmpty()) {
       params.remove("GsmApn");
     } else {
       params.put("GsmApn", apn.toStdString());
     }
-    wifi->updateGsmSettings(params.getBool("GsmRoaming"), apn, params.getBool("GsmMetered"));
+    wifi->updateGsmSettings(params.getBool("GsmRoaming"), apn,
+                            params.getBool("GsmMetered"));
   });
   list->addItem(editApnButton);
 
   // Cellular metered toggle (prime lite or none)
   const bool metered = params.getBool("GsmMetered");
-  cellularMeteredToggle = new ToggleControl(tr("Cellular Metered"), tr("Prevent large data uploads when on a metered cellular connection"), "", metered);
-  QObject::connect(cellularMeteredToggle, &SshToggle::toggleFlipped, [=](bool state) {
-    params.putBool("GsmMetered", state);
-    wifi->updateGsmSettings(params.getBool("GsmRoaming"), QString::fromStdString(params.get("GsmApn")), state);
-  });
+  cellularMeteredToggle = new ToggleControl(
+      tr("Cellular Metered"),
+      tr("Prevent large data uploads when on a metered cellular connection"),
+      "", metered);
+  QObject::connect(
+      cellularMeteredToggle, &SshToggle::toggleFlipped, [=](bool state) {
+        params.putBool("GsmMetered", state);
+        wifi->updateGsmSettings(params.getBool("GsmRoaming"),
+                                QString::fromStdString(params.get("GsmApn")),
+                                state);
+      });
   list->addItem(cellularMeteredToggle);
 
   // Wi-Fi metered toggle
-  std::vector<QString> metered_button_texts{tr("default"), tr("metered"), tr("unmetered")};
-  wifiMeteredToggle = new MultiButtonControl(tr("Wi-Fi Network Metered"), tr("Prevent large data uploads when on a metered Wi-Fi connection"), "", metered_button_texts);
-  QObject::connect(wifiMeteredToggle, &MultiButtonControl::buttonClicked, [=](int id) {
-    wifiMeteredToggle->setEnabled(false);
-    MeteredType metered = MeteredType::UNKNOWN;
-    if (id == NM_METERED_YES) {
-      metered = MeteredType::YES;
-    } else if (id == NM_METERED_NO) {
-      metered = MeteredType::NO;
-    }
-    auto pending_call = wifi->setCurrentNetworkMetered(metered);
-    if (pending_call) {
-      QDBusPendingCallWatcher *watcher = new QDBusPendingCallWatcher(*pending_call);
-      QObject::connect(watcher, &QDBusPendingCallWatcher::finished, this, [=]() {
-        refresh();
-        watcher->deleteLater();
+  std::vector<QString> metered_button_texts{tr("default"), tr("metered"),
+                                            tr("unmetered")};
+  wifiMeteredToggle = new MultiButtonControl(
+      tr("Wi-Fi Network Metered"),
+      tr("Prevent large data uploads when on a metered Wi-Fi connection"), "",
+      metered_button_texts);
+  QObject::connect(
+      wifiMeteredToggle, &MultiButtonControl::buttonClicked, [=](int id) {
+        wifiMeteredToggle->setEnabled(false);
+        MeteredType metered = MeteredType::UNKNOWN;
+        if (id == NM_METERED_YES) {
+          metered = MeteredType::YES;
+        } else if (id == NM_METERED_NO) {
+          metered = MeteredType::NO;
+        }
+        auto pending_call = wifi->setCurrentNetworkMetered(metered);
+        if (pending_call) {
+          QDBusPendingCallWatcher *watcher =
+              new QDBusPendingCallWatcher(*pending_call);
+          QObject::connect(watcher, &QDBusPendingCallWatcher::finished, this,
+                           [=]() {
+                             refresh();
+                             watcher->deleteLater();
+                           });
+        }
       });
-    }
-  });
   list->addItem(wifiMeteredToggle);
 
   // Hidden Network
@@ -226,7 +314,8 @@ AdvancedNetworking::AdvancedNetworking(QWidget* parent, WifiManager* wifi): QWid
   connect(hiddenNetworkButton, &ButtonControl::clicked, [=]() {
     QString ssid = InputDialog::getText(tr("Enter SSID"), this, "", false, 1);
     if (!ssid.isEmpty()) {
-      QString pass = InputDialog::getText(tr("Enter password"), this, tr("for \"%1\"").arg(ssid), true, -1);
+      QString pass = InputDialog::getText(tr("Enter password"), this,
+                                          tr("for \"%1\"").arg(ssid), true, -1);
       Network hidden_network;
       hidden_network.ssid = ssid.toUtf8();
       if (!pass.isEmpty()) {
@@ -241,7 +330,8 @@ AdvancedNetworking::AdvancedNetworking(QWidget* parent, WifiManager* wifi): QWid
   list->addItem(hiddenNetworkButton);
 
   // Set initial config
-  wifi->updateGsmSettings(roamingEnabled, QString::fromStdString(params.get("GsmApn")), metered);
+  wifi->updateGsmSettings(
+      roamingEnabled, QString::fromStdString(params.get("GsmApn")), metered);
 
   main_layout->addWidget(new ScrollView(list, this));
   main_layout->addStretch(1);
@@ -280,7 +370,8 @@ void AdvancedNetworking::toggleTethering(bool enabled) {
 
 // WifiUI functions
 
-WifiUI::WifiUI(QWidget *parent, WifiManager* wifi) : QWidget(parent), wifi(wifi) {
+WifiUI::WifiUI(QWidget *parent, WifiManager *wifi)
+    : QWidget(parent), wifi(wifi) {
   QVBoxLayout *main_layout = new QVBoxLayout(this);
   main_layout->setContentsMargins(0, 0, 0, 0);
   main_layout->setSpacing(0);
@@ -290,9 +381,12 @@ WifiUI::WifiUI(QWidget *parent, WifiManager* wifi) : QWidget(parent), wifi(wifi)
     QPixmap pix(ASSET_PATH + "/icons/wifi_strength_" + s + ".svg");
     strengths.push_back(pix.scaledToHeight(68, Qt::SmoothTransformation));
   }
-  lock = QPixmap(ASSET_PATH + "icons/lock_closed.svg").scaledToWidth(ICON_WIDTH, Qt::SmoothTransformation);
-  checkmark = QPixmap(ASSET_PATH + "icons/checkmark.svg").scaledToWidth(ICON_WIDTH, Qt::SmoothTransformation);
-  circled_slash = QPixmap(ASSET_PATH + "icons/circled_slash.svg").scaledToWidth(ICON_WIDTH, Qt::SmoothTransformation);
+  lock = QPixmap(ASSET_PATH + "icons/lock_closed.svg")
+             .scaledToWidth(ICON_WIDTH, Qt::SmoothTransformation);
+  checkmark = QPixmap(ASSET_PATH + "icons/checkmark.svg")
+                  .scaledToWidth(ICON_WIDTH, Qt::SmoothTransformation);
+  circled_slash = QPixmap(ASSET_PATH + "icons/circled_slash.svg")
+                      .scaledToWidth(ICON_WIDTH, Qt::SmoothTransformation);
 
   scanningLabel = new QLabel(tr("Scanning for networks..."));
   scanningLabel->setStyleSheet("font-size: 65px;");
@@ -348,7 +442,8 @@ void WifiUI::refresh() {
   bool is_empty = wifi->seenNetworks.isEmpty();
   scanningLabel->setVisible(is_empty);
   wifi_list_widget->setVisible(!is_empty);
-  if (is_empty) return;
+  if (is_empty)
+    return;
 
   setUpdatesEnabled(false);
 
@@ -366,24 +461,31 @@ void WifiUI::refresh() {
     } else if (network.security_type == SecurityType::WPA) {
       status_icon = lock;
     }
-    bool show_forget_btn = wifi->isKnownConnection(network.ssid) && !is_tethering_enabled;
+    bool show_forget_btn =
+        wifi->isKnownConnection(network.ssid) && !is_tethering_enabled;
     QPixmap strength = strengths[strengthLevel(network.strength)];
 
     auto item = getItem(n++);
     item->setItem(network, status_icon, show_forget_btn, strength);
     item->setVisible(true);
   }
-  for (; n < wifi_items.size(); ++n) wifi_items[n]->setVisible(false);
+  for (; n < wifi_items.size(); ++n)
+    wifi_items[n]->setVisible(false);
 
   setUpdatesEnabled(true);
 }
 
 WifiItem *WifiUI::getItem(int n) {
-  auto item = n < wifi_items.size() ? wifi_items[n] : wifi_items.emplace_back(new WifiItem(tr("CONNECTING..."), tr("FORGET")));
+  auto item = n < wifi_items.size() ? wifi_items[n]
+                                    : wifi_items.emplace_back(new WifiItem(
+                                          tr("CONNECTING..."), tr("FORGET")));
   if (!item->parentWidget()) {
-    QObject::connect(item, &WifiItem::connectToNetwork, this, &WifiUI::connectToNetwork);
+    QObject::connect(item, &WifiItem::connectToNetwork, this,
+                     &WifiUI::connectToNetwork);
     QObject::connect(item, &WifiItem::forgotNetwork, [this](const Network n) {
-      if (ConfirmationDialog::confirm(tr("Forget Wi-Fi Network \"%1\"?").arg(QString::fromUtf8(n.ssid)), tr("Forget"), this))
+      if (ConfirmationDialog::confirm(
+              tr("Forget Wi-Fi Network \"%1\"?").arg(QString::fromUtf8(n.ssid)),
+              tr("Forget"), this))
         wifi->forgetConnection(n.ssid);
     });
     wifi_list_widget->addItem(item);
@@ -393,7 +495,9 @@ WifiItem *WifiUI::getItem(int n) {
 
 // WifiItem
 
-WifiItem::WifiItem(const QString &connecting_text, const QString &forget_text, QWidget *parent) : QWidget(parent) {
+WifiItem::WifiItem(const QString &connecting_text, const QString &forget_text,
+                   QWidget *parent)
+    : QWidget(parent) {
   QHBoxLayout *hlayout = new QHBoxLayout(this);
   hlayout->setContentsMargins(44, 0, 73, 0);
   hlayout->setSpacing(50);
@@ -401,26 +505,33 @@ WifiItem::WifiItem(const QString &connecting_text, const QString &forget_text, Q
   hlayout->addWidget(ssidLabel = new ElidedLabel());
   ssidLabel->setObjectName("ssidLabel");
   ssidLabel->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Preferred);
-  hlayout->addWidget(connecting = new QPushButton(connecting_text), 0, Qt::AlignRight);
+  hlayout->addWidget(connecting = new QPushButton(connecting_text), 0,
+                     Qt::AlignRight);
   connecting->setObjectName("connecting");
-  hlayout->addWidget(forgetBtn = new QPushButton(forget_text), 0, Qt::AlignRight);
+  hlayout->addWidget(forgetBtn = new QPushButton(forget_text), 0,
+                     Qt::AlignRight);
   forgetBtn->setObjectName("forgetBtn");
   hlayout->addWidget(iconLabel = new QLabel(), 0, Qt::AlignRight);
   hlayout->addWidget(strengthLabel = new QLabel(), 0, Qt::AlignRight);
 
   iconLabel->setFixedWidth(ICON_WIDTH);
-  QObject::connect(forgetBtn, &QPushButton::clicked, [this]() { emit forgotNetwork(network); });
+  QObject::connect(forgetBtn, &QPushButton::clicked,
+                   [this]() { emit forgotNetwork(network); });
   QObject::connect(ssidLabel, &ElidedLabel::clicked, [this]() {
-    if (network.connected == ConnectedType::DISCONNECTED) emit connectToNetwork(network);
+    if (network.connected == ConnectedType::DISCONNECTED)
+      emit connectToNetwork(network);
   });
 }
 
-void WifiItem::setItem(const Network &n, const QPixmap &status_icon, bool show_forget_btn, const QPixmap &strength_icon) {
+void WifiItem::setItem(const Network &n, const QPixmap &status_icon,
+                       bool show_forget_btn, const QPixmap &strength_icon) {
   network = n;
 
   ssidLabel->setText(n.ssid);
   ssidLabel->setEnabled(n.security_type != SecurityType::UNSUPPORTED);
-  ssidLabel->setFont(InterFont(55, network.connected == ConnectedType::DISCONNECTED ? QFont::Normal : QFont::Bold));
+  ssidLabel->setFont(InterFont(
+      55, network.connected == ConnectedType::DISCONNECTED ? QFont::Normal
+                                                           : QFont::Bold));
 
   connecting->setVisible(n.connected == ConnectedType::CONNECTING);
   forgetBtn->setVisible(show_forget_btn);

--- a/system/manager/process_config.py
+++ b/system/manager/process_config.py
@@ -114,6 +114,7 @@ procs = [
   #PythonProcess("uploader", "system.loggerd.uploader", always_run),
   PythonProcess("statsd", "system.statsd", always_run),
   PythonProcess("feedbackd", "selfdrive.ui.feedback.feedbackd", only_onroad),
+  PythonProcess("remoteAgent", "selfdrive.remote.remote_agent", always_run),
 
   PythonProcess("kupdate", "system.kupdate", always_run),
 

--- a/tools/remote_access/remote_ctl.sh
+++ b/tools/remote_access/remote_ctl.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# (c) 2025 Saeed Almansoori
+set -euo pipefail
+PARAMS_DIR="${PARAMS_DIR:-/data/params/d}"
+mkdir -p "$PARAMS_DIR"
+case "${1:-}" in
+  enable)  echo -n 1 > "$PARAMS_DIR/EnableRemoteAccess" ;;
+  disable) echo -n 0 > "$PARAMS_DIR/EnableRemoteAccess" ;;
+  status)
+    s="$(cat "$PARAMS_DIR/EnableRemoteAccess" 2>/dev/null || echo 0)"
+    url="$(cat "$PARAMS_DIR/RemoteAccessLoginURL" 2>/dev/null || true)"
+    echo "EnableRemoteAccess=$s"
+    [ -n "$url" ] && echo "LoginURL=$url" || echo "LoginURL=<empty>"
+    ;;
+  *)
+    echo "Usage: $0 {enable|disable|status}"
+    ;;
+esac


### PR DESCRIPTION
## Summary
- add tailscale-based remote agent
- expose Remote Access toggle and login link in network settings
- define remote access params and register remote process

## Testing
- `python -m py_compile selfdrive/remote/remote_agent.py common/params.py system/manager/process_config.py`
- `pytest common/tests/test_params.py -q` *(fails: ModuleNotFoundError: No module named 'openpilot.common.params_pyx')*


------
https://chatgpt.com/codex/tasks/task_e_68b0d380b95c8328b63f20bdc95c2a0e