### PR TITLE
Add Genesis GV80 1st Gen CAN-FD support

### DIFF
--- a/opendbc_repo/opendbc/car/hyundai/fingerprints.py
+++ b/opendbc_repo/opendbc/car/hyundai/fingerprints.py
@@ -1254,6 +1254,18 @@ FW_VERSIONS = {
       b'\xf1\x00SG2_ RDR -----      1.00 1.01 99110-AT000         ',
     ],
   },
+  # Genesis GV80 (CAN-FD) — fill FW strings after running the FW dump tool on the car.
+  CAR.GENESIS_GV80_1ST_GEN: {
+    # Expected ECUs on HKG CAN-FD:
+    #  - Forward Radar: 0x7D0
+    #  - Forward Camera (MFC): 0x7C4
+    (Ecu.fwdRadar, 0x7d0, None): [
+      # TODO: insert exact FW string(s) after dump
+    ],
+    (Ecu.fwdCamera, 0x7c4, None): [
+      # TODO: insert exact FW string(s) after dump
+    ],
+  },
   CAR.GENESIS_GV80: {
     (Ecu.fwdCamera, 0x7c4, None): [
       b'\xf1\x00JX1 MFC  AT USA LHD 1.00 1.02 99211-T6110 220513',

--- a/opendbc_repo/opendbc/car/hyundai/values.py
+++ b/opendbc_repo/opendbc/car/hyundai/values.py
@@ -645,6 +645,16 @@ class CAR(Platforms):
     [HyundaiCarDocs("Genesis G90 2017-20", "All", car_parts=CarParts.common([CarHarness.hyundai_c]))],
     CarSpecs(mass=2200, wheelbase=3.15, steerRatio=12.069),
   )
+  # Genesis GV80 (1st Gen, CAN-FD)
+  GENESIS_GV80_1ST_GEN = HyundaiCanFDPlatformConfig(
+    [HyundaiCarDocs("Genesis GV80 (1st Gen, CAN-FD)", "All", car_parts=CarParts.common([CarHarness.hyundai_a]))],
+    CarSpecs(
+      mass=2200,        # TODO: refine after first drive / official spec
+      wheelbase=2.95,   # TODO: refine
+      steerRatio=13.0,  # from liveParameters (log)
+      tireStiffnessFactor=0.70
+    ),
+  )
   GENESIS_GV80 = HyundaiCanFDPlatformConfig(
     [HyundaiCarDocs("Genesis GV80 2023", "All", car_parts=CarParts.common([CarHarness.hyundai_m]))],
     CarSpecs(mass=2258, wheelbase=2.95, steerRatio=14.14),

--- a/opendbc_repo/opendbc/car/torque_data/override.toml
+++ b/opendbc_repo/opendbc/car/torque_data/override.toml
@@ -66,6 +66,8 @@ legend = ["LAT_ACCEL_FACTOR", "MAX_LAT_ACCEL_MEASURED", "FRICTION"]
 "KIA_NIRO_HEV_2ND_GEN" = [2.42, 2.5, 0.12]
 "KIA_NIRO_EV_2ND_GEN" = [2.05, 2.5, 0.14]
 "GENESIS_GV80" = [2.5, 2.5, 0.1]
+# Genesis GV80 initial lateral tuning (conservative; adjust with road logs)
+"GENESIS_GV80_1ST_GEN" = [2.30, 2.30, 0.10]
 "KIA_CARNIVAL_4TH_GEN" = [1.75, 1.75, 0.15]
 "GMC_ACADIA" = [1.6, 1.6, 0.2]
 "LEXUS_IS_TSS2" = [2.0, 2.0, 0.1]


### PR DESCRIPTION
## Summary
- add Genesis GV80 1st Gen CAN-FD platform with initial specs
- provide conservative lateral tuning override for GV80 1st Gen
- stub firmware fingerprints for GV80 1st Gen CAN-FD

## Testing
- ⚠️ `pre-commit run --files opendbc_repo/opendbc/car/hyundai/values.py opendbc_repo/opendbc/car/torque_data/override.toml opendbc_repo/opendbc/car/hyundai/fingerprints.py` *(repository missing `.pre-commit-config.yaml`)*
- ⚠️ `pytest opendbc_repo/opendbc/car/hyundai/tests/test_hyundai.py` *(missing dependency: hypothesis; install attempt blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68b0debfe454832880ad3909e527d8f7